### PR TITLE
Adicionado Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(CombatC VERSION 1.1.0) 
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/")
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/release)
+
+FIND_PACKAGE(Allegro REQUIRED)
+
+IF(ALLEGRO_FOUND)
+   INCLUDE_DIRECTORIES(${ALLEGRO_INCLUDE_DIR})
+ENDIF(ALLEGRO_FOUND)
+
+add_executable(combat core/src/combat.c modules/src/collision.c modules/src/drawer.c modules/src/obstacle.c modules/src/tank.c screens/src/game.c screens/src/score.c)
+
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+    target_link_libraries(combat PUBLIC ${MATH_LIBRARY} ${ALLEGRO_LIBRARY})
+endif()

--- a/cmake_modules/FindAllegro.cmake
+++ b/cmake_modules/FindAllegro.cmake
@@ -1,0 +1,69 @@
+# - Try to find Allegro
+# Once done this will define
+#  ALLEGRO_FOUND - System has Allegro
+#  ALLEGRO_INCLUDE_DIRS - The Allegro include directories
+#  ALLEGRO_LIBRARIES - The libraries needed to use Allegro
+#  ALLEGRO_DEFINITIONS - Compiler switches required for using Allegro
+
+if(WIN32)
+    set(ALLEGRO_INCLUDE_HINTS
+        ${CMAKE_BINARY_DIR}/${ALLEGRO_PATH}/include ${ALLEGRO_PATH}/include)
+    set(ALLEGRO_LIBRARY_HINTS
+        ${CMAKE_BINARY_DIR}/${ALLEGRO_PATH}/bin ${ALLEGRO_PATH}/bin)
+else(WIN32)
+    find_package(PkgConfig)
+    pkg_check_modules(PC_ALLEGRO QUIET allegro-5.0)
+    set(ALLEGRO_DEFINITIONS ${PC_ALLLEGRO_CFLAGS_OTHER})
+
+    set(ALLEGRO_INCLUDE_HINTS
+        ${PC_ALLEGRO_INCLUDEDIR} ${PC_ALLEGRO_INCLUDE_DIRS})
+    set(ALLEGRO_LIBRARY_HINTS
+        ${PC_ALLEGRO_LIBDIR} ${PC_ALLEGRO_LIBRARY_DIRS})
+endif(WIN32)
+
+find_path(ALLEGRO_INCLUDE_DIR allegro5/allegro.h
+    HINTS ${ALLEGRO_INCLUDE_HINTS})
+
+find_library(ALLEGRO_LIBRARY
+    NAMES allegro allegro-5.0.2-mt
+    HINTS ${ALLEGRO_LIBRARY_HINTS})
+
+find_library(ALLEGRO_FONT_LIBRARY
+    NAMES allegro_font allegro_font-5.0.2-mt
+    HINTS ${ALLEGRO_LIBRARY_HINTS})
+
+find_library(ALLEGRO_IMAGE_LIBRARY
+    NAMES allegro_image allegro_image-5.0.2-mt
+    HINTS ${ALLEGRO_LIBRARY_HINTS})
+
+find_library(ALLEGRO_TTF_LIBRARY
+    NAMES allegro_ttf allegro_ttf-5.0.2-mt
+    HINTS ${ALLEGRO_LIBRARY_HINTS})
+
+find_library(ALLEGRO_PRIMITIVES_LIBRARY
+    NAMES allegro_primitives allegro_primitives-5.0.2-mt
+    HINTS ${ALLEGRO_LIBRARY_HINTS})
+
+set(ALLEGRO_LIBRARIES
+        ${ALLEGRO_LIBRARY}
+        ${ALLEGRO_FONT_LIBRARY}
+        ${ALLEGRO_IMAGE_LIBRARY}
+        ${ALLEGRO_TTF_LIBRARY}
+        ${ALLEGRO_PRIMITIVES_LIBRARY}
+)
+set(ALLEGRO_INCLUDE_DIRS ${ALLEGRO_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set ALLEGRO_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Allegro DEFAULT_MSG
+    ALLEGRO_LIBRARY
+    ALLEGRO_FONT_LIBRARY
+    ALLEGRO_IMAGE_LIBRARY
+    ALLEGRO_TTF_LIBRARY
+    ALLEGRO_PRIMITIVES_LIBRARY
+    ALLEGRO_INCLUDE_DIR
+)
+
+mark_as_advanced(ALLEGRO_INCLUDE_DIR ALLEGRO_LIBRARY ALLEGRO_FONT_LIBRARY
+    ALLEGRO_IMAGE_LIBRARY ALLEGRO_TTF_LIBRARY)


### PR DESCRIPTION
No estado atual do projeto, ele é compilado usando uma .dll do Windows diretamente, tornando difícil compilar para Linux.

Tudo que eu fiz foi adicionar um CMake que faz a mesma coisa que o "Makefile" já fazia, porém ele também procura dentro do sistema operacional da pessoa onde está as ferramentas de desenvolvimento do allegro, logo permitindo com que a compilação de sistemas Linux e Windows seja possível.

Um aviso importante, mas o projeto parece que está preso na versão 5.0 porque eu tentei com o allegro 5.2.8 e infelizmente o CMake me alertava de funções inexistentes. Pode ser que eu também tenha feito o "link" de forma errado, mas fique a vontade para usar o cmake que eu fiz.